### PR TITLE
Specify numpy version in requirements.txt

### DIFF
--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,7 +5,9 @@ pexpect
 torch==1.4
 torchvision==0.5.0
 tensorflow==1.15.4
-numpy==1.16.2
+# TF 1.15.4 has requirement numpy<1.19.0,>=1.16.0
+# and numpy==1.19.2 throws numpy.ufunc has the wrong size error
+numpy==1.18.5
 pandas
 pyyaml
 docker

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,7 +5,7 @@ pexpect
 torch==1.4
 torchvision==0.5.0
 tensorflow==1.15.4
-numpy
+numpy==1.16.2
 pandas
 pyyaml
 docker


### PR DESCRIPTION
## Description

Numpy 1.16.2 is the latest version where I could sidestep the following three errors
* ERROR: determined 0.13.6.dev0 has requirement numpy>=1.16.2, but you'll have numpy 1.16.1 which is incompatible.
* ERROR: tensorflow 1.15.4 has requirement numpy<1.19.0,>=1.16.0, but you'll have numpy 1.19.2 which is incompatible.
* RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 216, got 192

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
